### PR TITLE
allow quill v2 beta in peerDependencies

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -83,7 +83,7 @@ export const useQuill = (options: QuillOptionsStatic | undefined = { theme, modu
 
   useEffect(() => {
     if (!obj.Quill) {
-      setObj((prev) => assign(prev, { Quill: require('quill') }));
+      setObj((prev) => assign(prev, { Quill }));
     }
     if (obj.Quill && !obj.quill && quillRef && quillRef.current && isLoaded) {
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"rich-text-editor"
 	],
 	"peerDependencies": {
-		"quill": "^1.3.7",
+		"quill": "^1.3.7 || ^2.0.0-dev.0",
 		"react": "^17.0.2 || ^18.0.0-0",
 		"react-dom": "^17.0.2 || ^18.0.0-0"
 	},


### PR DESCRIPTION
According to the docs v2 beta has zero API changes. I want to try out the new beta due to ViteJS errors on production builds with v1