### PR TITLE
2.0.3v remove commonjs option in package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "react-quilljs",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"description": "React Hook Wrapper for Quill, powerful rich text editor",
 	"license": "MIT",
 	"repository": "gtgalone/react-quilljs",
@@ -22,7 +22,6 @@
 		"lib",
 		"esm"
 	],
-	"type": "commonjs",
 	"exports": {
 		"require": "./lib/index.js",
 		"import": "./esm/index.js",


### PR DESCRIPTION
The "type" option was removed from the package.json file to correct the status quo 

that had failed because the compiled file was not recognized as an esm during the npm run build in nextjs.