### PR TITLE
Removed clean from formats

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -39,7 +39,6 @@ const formats = [
   'video',
   'color',
   'background',
-  'clean',
 ];
 
 function assign(target: any, _varArgs: any) {
@@ -83,10 +82,9 @@ export const useQuill = (options: QuillOptions | undefined = { theme, modules, f
 
   useEffect(() => {
     if (!obj.Quill) {
-      setObj((prev) => assign(prev, { Quill: require('quill').default }));
+      setObj(prev => assign(prev, { Quill: require('quill').default }));
     }
     if (obj.Quill && !obj.quill && quillRef && quillRef.current && isLoaded) {
-
       const opts = assign(options, {
         modules: assign(modules, options.modules),
         formats: options.formats || formats,


### PR DESCRIPTION
**Fixed the error:**

- `quill Cannot register "clean" specified in "formats" config. Are you sure it was registered?`

**Resolution:**

- Removed `clean` from the `formats` configuration, as `clean` is not a format but a module.