### PR TITLE
Remove unnecessary call to require()

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -82,7 +82,7 @@ export const useQuill = (options: QuillOptions | undefined = { theme, modules, f
 
   useEffect(() => {
     if (!obj.Quill) {
-      setObj(prev => assign(prev, { Quill: require('quill').default }));
+      setObj(prev => assign(prev, { Quill }));
     }
     if (obj.Quill && !obj.quill && quillRef && quillRef.current && isLoaded) {
       const opts = assign(options, {


### PR DESCRIPTION
We're getting this error when running our app built with Vite. I believe this will fix the issue. Thanks!